### PR TITLE
修复真机上获取nativeScale不正确的问题

### DIFF
--- a/src/zygame/utils/hl/IOSTools.hx
+++ b/src/zygame/utils/hl/IOSTools.hx
@@ -1,8 +1,8 @@
 package zygame.utils.hl;
-
+import hxd.impl.Float32;
 @:hlNative("iostools")
 class IOSTools {
-	public static function get_pixel_ratio():Float {
+	public static function get_pixel_ratio():Float32 {
 		return 1;
 	}
 }


### PR DESCRIPTION
把Float 换成了Float32